### PR TITLE
Use the openstack command-line tool instead of glance.

### DIFF
--- a/howto-upload-images-to-openstack.md
+++ b/howto-upload-images-to-openstack.md
@@ -4,7 +4,7 @@ How to upload images to Openstack
 Preparatory steps
 -----------------
 
-1. Install glance client and keystone client. Glance is image service for OpenStack and keystone is an auth library
+1. Install the openstack client, e.g. by running `pip install python-openstackclient` in a fresh virtualenv.
 2. Install gpg, and download [signature keys for ubuntu](https://wiki.edubuntu.org/SecurityTeam/FAQ) When I was 
    downloading the images following fingerprint was used: `D2EB 4462 6FDD C30B 513D 5BB7 1A5D 6C4C 7DB8 7C81`, 
    with following short ID: `7DB87C81`
@@ -23,6 +23,11 @@ Upload the images
 
 1. Download the rc file: go to horizon console `Access ans Security` -> `API Access` -> `Download RC File`.
 2. Source openstack rc file. 
-3. Upload the image: `glance image-create --container-format=bare --disk-format=qcow2 --file trusty-server-cloudimg-amd64-disk1.img --name nonmodified-trusty-14.04`
+3. Upload the image:
 
-   Note image format is qcow2 despite different image extension. 
+        openstack image create --container-format=bare --disk-format=qcow2 \
+            --file trusty-server-cloudimg-amd64-disk1.img trusty-14.04-unmodified-`date +%Y%m%d`
+
+   Note image format is qcow2 despite different image extension.  It should be possible to use the `glance`
+   client instead of the `openstack` command-line tool, but we had problems with `glance` ignoring the OpenStack
+   region in the past.


### PR DESCRIPTION
I had problems with `glance` ignoring the OpenStack region, while using `openstack` worked fine, so I'm updating the documentation accordingly.
